### PR TITLE
chore: release 3.2.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: open_cdp_flutter_sdk
 description: A Flutter SDK for integrating with the OpenCDP platform. Track user
   events, screen views, and device attributes with automatic lifecycle tracking
   and dual write to Customer.io.
-version: 3.2.0
+version: 3.2.2
 homepage: https://github.com/code-matic/opencdp-flutter-sdk
 repository: https://github.com/code-matic/opencdp-flutter-sdk
 documentation: https://github.com/code-matic/opencdp-flutter-sdk#readme


### PR DESCRIPTION
## Summary
- Bumps `open_cdp_flutter_sdk` to **3.2.2** for pub.dev publish (already uploaded).
- Includes CHANGELOG entries for 3.2.0–3.2.2 (turnkey push setup, NSE helpers, big-picture layout fixes).

## Test plan
- [x] `dart analyze` / `flutter test`
- [x] `dart pub publish` → https://pub.dev/packages/open_cdp_flutter_sdk/versions/3.2.2


Made with [Cursor](https://cursor.com)